### PR TITLE
Support multiple email recipients (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # The Gmail address the digest will be sent FROM
 GMAIL_FROM=your_email@gmail.com
 
-# ── Digest Recipient ───────────────────────────────────────
-# The email address the digest will be delivered TO
-# Can be the same as GMAIL_FROM or a different address
+# ── Digest Recipient(s) ────────────────────────────────────
+# The email address(es) the digest will be delivered TO
+# Can be the same as GMAIL_FROM or different addresses
+# Supports multiple recipients separated by comma or semicolon
 GMAIL_TO=your_email@gmail.com
+# GMAIL_TO=person1@gmail.com,person2@gmail.com
+# GMAIL_TO=person1@gmail.com;person2@gmail.com;person3@gmail.com
 
 # ── Gmail App Password ─────────────────────────────────────
 # NOT your Gmail login password — a separate 16-char app password

--- a/main.py
+++ b/main.py
@@ -203,16 +203,21 @@ def compile_digest(articles, topics):
 
 
 def send_email(html_content, subject, from_email, to_email, app_password):
-    """Send HTML email via Gmail SMTP."""
+    """Send HTML email via Gmail SMTP.
+
+    to_email supports multiple addresses separated by comma or semicolon.
+    Example: 'a@gmail.com,b@gmail.com' or 'a@gmail.com;b@gmail.com'
+    """
+    recipients = [r.strip() for r in re.split(r"[,;]", to_email) if r.strip()]
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject
     msg["From"] = from_email
-    msg["To"] = to_email
+    msg["To"] = ", ".join(recipients)
     msg.attach(MIMEText(html_content, "html"))
 
     with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
         server.login(from_email, app_password)
-        server.sendmail(from_email, to_email, msg.as_string())
+        server.sendmail(from_email, recipients, msg.as_string())
 
 
 def main():


### PR DESCRIPTION
## Summary
- Update `send_email()` to accept multiple recipients separated by comma or semicolon
- Whitespace around addresses is stripped automatically
- Single recipient behaviour unchanged (no regression)

## Changes
| File | Change |
|---|---|
| `main.py` | `send_email()` splits `GMAIL_TO` on `,` or `;` and strips whitespace |
| `test_main.py` | 4 new tests added, 1 existing test updated → 31 tests total |
| `README.md` | `.env` sample updated with multiple recipient examples |

## Example `.env` usage
```env
# Comma separated
GMAIL_TO=person1@gmail.com,person2@gmail.com

# Semicolon separated
GMAIL_TO=person1@gmail.com;person2@gmail.com;person3@gmail.com
```

## Test plan
- [x] 31 unit tests passing
- [x] Single recipient works as before (no regression)
- [x] Comma-separated recipients all receive the digest
- [x] Semicolon-separated recipients all receive the digest
- [x] Whitespace around addresses handled gracefully

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)