### PR TITLE
Add multi-user personalized digest support (v1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ rss-digest-agent/
 ├── Dockerfile        # Docker container definition
 ├── requirements.txt  # Python dependencies
 ├── main.py           # Main agent logic
-├── test_main.py      # Unit tests (27 tests)
+├── test_main.py      # Unit tests (58 tests)
 └── README.md
 ```
 
@@ -85,6 +85,34 @@ GMAIL_APP_PASSWORD=your16charapppassword
 
 Edit `config.yaml` to add/remove RSS feeds or change the topics the AI filters for.
 
+### 5. Configure user groups (optional)
+
+The agent supports multiple user groups, each with their own topics and email recipients. RSS feeds are fetched **once** and shared; filtering, summarization, and email delivery happen independently per group.
+
+Add a `users:` block in `config.yaml`:
+
+```yaml
+users:
+  - name: Finance Team
+    emails:
+      - person1@gmail.com
+      - person2@gmail.com
+    topics:
+      - AI use cases for Finance Department in a bank
+      - Regulatory technology and compliance automation
+
+  - name: Technology Team
+    emails:
+      - tech@gmail.com
+    topics:
+      - AI and Claude for software development
+      - Open source AI models and LLM infrastructure
+```
+
+- When `users:` is present, `GMAIL_TO` is ignored — recipients are defined per group in `config.yaml`
+- When `users:` is absent, the agent falls back to single-user mode using `GMAIL_TO` and `topics:` from `config.yaml`
+- Each group receives a digest with its own subject line: `AI Research Digest (Finance Team) - 2026-02-18`
+
 ---
 
 ## Running
@@ -93,15 +121,21 @@ Edit `config.yaml` to add/remove RSS feeds or change the topics the AI filters f
 python3 main.py
 ```
 
-Expected output:
+Expected output (multi-user mode):
 ```
-Step 1/4: Fetching articles from RSS feeds...
-  Found 30 total articles
-Step 2/4: Filtering relevant articles with AI...
-  Found 7 relevant articles
-Step 3/4: Summarizing articles...
-Step 4/4: Sending digest email...
-  Digest sent to your_email@gmail.com
+Step 1: Fetching articles from RSS feeds...
+  Found 30 unique articles
+  28 new (skipped 2 already seen)
+
+── User group: Finance Team ────────────────────────
+  Found 5 relevant articles
+  Digest sent to prasgenai@gmail.com,ssohni@gmail.com (Finance Team)
+
+── User group: Technology Team ────────────────────────
+  Found 4 relevant articles
+  Digest sent to prasgenai@gmail.com,ssohni@gmail.com (Technology Team)
+
+  Cached 28 article URLs
 Done!
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,28 @@
+users:
+  - name: Finance Team
+    emails:
+      - prasgenai@gmail.com
+      - ssohni@gmail.com
+    topics:
+      - AI use cases for Finance Department in a bank (fraud detection, risk management, compliance, financial reporting, forecasting)
+      - Regulatory technology (RegTech) and compliance automation in banking
+
+  - name: Technology Team
+    emails:
+      - prasgenai@gmail.com
+      - ssohni@gmail.com
+    topics:
+      - AI and Claude for software development (coding agents, developer productivity, code review, LLM tooling, agentic workflows)
+      - Open source AI models and LLM infrastructure
+
+  - name: A-Level Students
+    emails:
+      - tnps39944t@gmail.com
+    topics:
+      - Singapore and overseas scholarships available to pre-university students studying in Singapore under the A-Level curriculum (local university scholarships, government scholarships, international university scholarships)
+      - Scholarship application deadlines and tips for pre-university A-Level students in Singapore applying to local and overseas universities
+
+# Fallback (used only if 'users' key above is absent)
 topics:
   - AI use cases for Finance Department in a bank (fraud detection, risk management, compliance, financial reporting, forecasting)
   - AI and Claude for software development (coding agents, developer productivity, code review, LLM tooling, agentic workflows)
@@ -25,3 +50,14 @@ feeds:
   - https://www.deeplearning.ai/the-batch/feed/
   - https://venturebeat.com/category/ai/feed/
   - https://thenewstack.io/feed/
+
+  # Singapore Scholarships & Education
+  - https://www.scholarshipsguidance.com/feed/
+  - https://sgtutorials.com.sg/feed/
+  - https://www.channelnewsasia.com/rssfeeds/8395986
+  - https://www.straitstimes.com/RSS/singapore
+
+  # International Scholarships & Opportunities
+  - https://opportunitydesk.org/feed/
+  - https://www.scholars4dev.com/feed/
+  - https://afterschoolasia.com/feed/


### PR DESCRIPTION
## Summary

- Add `resolve_users()` function — returns per-user config list, or wraps single-user fallback from `GMAIL_TO` + `topics`
- Rewrite `main()` with a **shared fetch phase** (RSS fetched once for all groups) and a **per-user loop** (filter → scrape → summarize → email)
- Add `users:` block to `config.yaml` with three groups: Finance Team, Technology Team, A-Level Students
- Add 7 Singapore + international scholarship RSS feeds for the A-Level Students group
- Subject line now includes group name: `AI Research Digest (Finance Team) - 2026-02-18`
- Fully backward-compatible: if `users:` key is absent, falls back to single-user mode via `GMAIL_TO`

## Test plan

- [ ] Run `python3 -m unittest test_main -v` — expect **58 tests passing** (45 existing + 7 `TestResolveUsers` + 6 `TestMainMultiUser`)
- [ ] Verify `fetch_articles` is called only once regardless of user group count
- [ ] Verify each user group receives a separate email with the correct subject and recipients
- [ ] Verify removing `users:` from `config.yaml` falls back to single-user mode cleanly
- [ ] Run `python3 main.py` end-to-end and confirm two digest emails delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)