### PR TITLE
Fix two bugs in summarize_articles (v1.6.2)

### DIFF
--- a/main.py
+++ b/main.py
@@ -211,21 +211,23 @@ Score 1-10 (7+ = relevant). Articles:
     return relevant[:12]  # Cap at 12 articles per digest
 
 
-def summarize_articles(articles):
+def summarize_articles(articles, topics):
     """Summarize each relevant article into 3 bullet points (batched)."""
     if not articles:
         return []
 
     batch_size = 5
+    topics_str = "\n".join(f"- {t}" for t in topics)
 
     for i in range(0, len(articles), batch_size):
         batch = articles[i:i + batch_size]
         articles_text = ""
         for j, article in enumerate(batch, 1):
-            articles_text += f"[{j}] Title: {article['title']}\nContent: {article['summary'][:400]}\n\n"
+            articles_text += f"[{j}] Title: {article['title']}\nContent: {article['summary']}\n\n"
 
         prompt = f"""Summarize each article in exactly 3 concise bullet points.
-Focus on practical insights for finance and technology professionals.
+Focus on insights relevant to these topics:
+{topics_str}
 
 {articles_text}
 Format EXACTLY as (no extra text before [1]):
@@ -428,7 +430,7 @@ def main():
                     scraped_count += 1
             print(f"  Scraped {scraped_count} new articles")
 
-        summarized = summarize_articles(relevant)
+        summarized = summarize_articles(relevant, topics)
 
         if sentiment_cfg.get("enabled", True):
             print("  Analyzing article sentiment...")


### PR DESCRIPTION
## Summary

Fixes #17 — two bugs in `summarize_articles()`.

## Bug 1 — Scraped content truncated to 400 chars

**Before:**
```python
articles_text += f"... Content: {article['summary'][:400]}\n\n"
```
**After:**
```python
articles_text += f"... Content: {article['summary']}\n\n"
```
`scrape_article()` already caps content at `max_chars` (default 2000). The extra `[:400]` slice was silently discarding 80% of scraped text before the LLM saw it.

## Bug 2 — Hardcoded audience in summarization prompt

**Before:**
```python
def summarize_articles(articles):
    ...
    prompt = "... Focus on practical insights for finance and technology professionals."
```
**After:**
```python
def summarize_articles(articles, topics):
    topics_str = "\n".join(f"- {t}" for t in topics)
    prompt = f"... Focus on insights relevant to these topics:\n{topics_str}"
```
The function now receives the user group's actual topics and tailors the prompt accordingly — producing relevant summaries for all groups including A-Level Students (scholarships).

## Test plan

- [x] 81 tests, all passing
- [x] `test_topics_included_in_prompt` — verifies group topics appear in the LLM prompt
- [x] `test_full_summary_used_not_truncated` — verifies full summary (1000 chars) reaches the prompt untruncated
- [x] All `TestMainMultiUser` mocks updated to match new signature `(articles, topics)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)