### PR TITLE
Replace CC BY-NC-ND with proprietary All Rights Reserved license (v1.7.1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,22 @@
-Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International
-(CC BY-NC-ND 4.0)
+Proprietary License
 
-Copyright (c) 2026 Prashant
+Copyright (c) 2026 Prashant. All Rights Reserved.
 
-You are free to:
-  Share — copy and redistribute the material in any medium or format
+This software and its source code are the exclusive property of the author.
 
-Under the following terms:
-  Attribution       — You must give appropriate credit, provide a link to the
-                      license, and indicate if changes were made.
-  NonCommercial     — You may not use the material for commercial purposes.
-  NoDerivatives     — If you remix, transform, or build upon the material,
-                      you may not distribute the modified material.
+Permission is granted to:
+  - View and read the source code for personal, educational, or reference purposes
 
-No additional restrictions — You may not apply legal terms or technological
-measures that legally restrict others from doing anything the license permits.
+Permission is NOT granted to:
+  - Copy, reproduce, or redistribute the source code or any portion of it
+  - Modify, adapt, or create derivative works based on this software
+  - Use this software or any portion of it for commercial purposes
+  - Sublicense, sell, or transfer any rights to this software
 
-Full license text: https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode
+Any use beyond viewing requires explicit written consent from the author.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY CLAIM, DAMAGES, OR
+OTHER LIABILITY ARISING FROM THE USE OF THIS SOFTWARE.
+
+Contact: https://github.com/prasgenai

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSS Research Digest Agent
 
-[![License: CC BY-NC-ND 4.0](https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-nc-nd/4.0/)
+[![License: Proprietary](https://img.shields.io/badge/License-Proprietary-red.svg)](./LICENSE)
 [![Built with Claude Code](https://img.shields.io/badge/Built%20with-Claude%20Code-orange?logo=anthropic)](https://claude.ai/claude-code)
 
 An agentic app that fetches articles from RSS feeds, filters them by topic using AI, summarizes them into bullet points, and emails you a daily digest.
@@ -277,11 +277,11 @@ rm digest_cache.db
 
 ## License
 
-Copyright (c) 2026 Prashant. All rights reserved.
+Copyright (c) 2026 Prashant. All Rights Reserved.
 
-This project is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License (CC BY-NC-ND 4.0)](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+This project uses a **proprietary license**. You may view and read the source code for personal or educational purposes. Copying, modifying, distributing, or using this software commercially requires explicit written consent from the author.
 
-You may view and share this code with attribution. You may **not** use it commercially or distribute modified versions.
+See the [LICENSE](./LICENSE) file for full terms.
 
 ---
 

--- a/SOFTWARE_DESIGN_DOCUMENT.md
+++ b/SOFTWARE_DESIGN_DOCUMENT.md
@@ -3,7 +3,7 @@
 
 | Field         | Details                          |
 |---------------|----------------------------------|
-| Document Ver  | 1.7                              |
+| Document Ver  | 1.7.1                            |
 | Date          | February 2026                    |
 | Author        | Prashant                         |
 | Status        | Released                         |
@@ -636,6 +636,7 @@ Edit `config.yaml` — no code changes needed. The agent picks up changes on the
 | Sentiment analysis | Each article classified as Positive/Negative/Neutral; colour-coded badge in email digest | ✅ Done (v1.6) |
 | Security: emails to .env | Move per-group recipient emails from config.yaml to .env to prevent PII in version control | ✅ Done (v1.6.1) |
 | Topic-aware summarization | summarize_articles() now accepts topics; prompt tailored per user group; full scraped content used (no 400-char truncation) | ✅ Done (v1.7) |
+| Proprietary license | Replace CC BY-NC-ND 4.0 (incompatible with software) with a proprietary All Rights Reserved license | ✅ Done (v1.7.1) |
 
 ### Potential Future Enhancements
 
@@ -650,5 +651,5 @@ Edit `config.yaml` — no code changes needed. The agent picks up changes on the
 
 ---
 
-*Document generated for RSS Research Digest Agent v1.7*
+*Document generated for RSS Research Digest Agent v1.7.1*
 *All technologies used are open source.*


### PR DESCRIPTION
## Summary

Closes #19 — CC BY-NC-ND 4.0 is inappropriate for software projects.

## Why CC BY-NC-ND was wrong for this project

| Issue | Detail |
|---|---|
| Wrong category | CC licenses are for creative works (art, music, writing), not code |
| ND clause conflict | Prohibits derivatives, but all dependencies (MIT, Apache, BSD) explicitly allow modification |
| Industry standard | Software developers and legal teams don't recognise CC licenses on code |

## What the new proprietary license does

| Action | Permitted? |
|---|---|
| View / read source code | ✅ Yes |
| Copy or reproduce | ❌ No |
| Modify or create derivatives | ❌ No |
| Commercial use | ❌ No |
| Distribute | ❌ No — requires written consent |

## Files changed

| File | Change |
|---|---|
| `LICENSE` | Rewritten as proprietary All Rights Reserved |
| `README.md` | Updated badge (`Proprietary`) and license section |
| `SOFTWARE_DESIGN_DOCUMENT.md` | Bumped to v1.7.1, added changelog entry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)