### PR TITLE
fix: all 9 bugs v1.9 — crash fix, guards, validation, XSS, lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ rss-digest-agent/
 ├── Dockerfile            # Docker container definition
 ├── requirements.txt      # Python dependencies
 ├── main.py               # Main agent logic
-├── test_main.py          # Unit tests (83 tests)
+├── test_main.py          # Unit tests (99 tests)
 └── README.md
 ```
 
@@ -175,6 +175,19 @@ This runs the agent every day at 8:00 AM and logs output to `/tmp/digest.log`.
 
 ---
 
+## Configuring the Lookback Window
+
+By default, the agent fetches articles published within the last **24 hours**. You can change this in `config.yaml`:
+
+```yaml
+fetch:
+  lookback_hours: 24   # increase for longer windows (e.g. 48 for weekends)
+```
+
+Set a longer window (e.g. `48`) to catch articles you may have missed, or a shorter one for high-volume feeds.
+
+---
+
 ## Adding More RSS Feeds
 
 Edit `config.yaml` and add feed URLs under `feeds:`:
@@ -190,7 +203,7 @@ To find the RSS feed URL for any website, look for an RSS icon or append `/feed`
 
 ## Sentiment Analysis
 
-When enabled, each article in the digest is classified as **Positive**, **Negative**, or **Neutral** based on its implications for finance and technology professionals. The sentiment label appears colour-coded in the email next to the relevance score.
+When enabled, each article in the digest is classified as **Positive**, **Negative**, or **Neutral** based on its implications for the intended audience. The sentiment label appears colour-coded in the email next to the relevance score.
 
 Configure in `config.yaml`:
 
@@ -253,7 +266,7 @@ scraping:
 ```
 
 - Scraping runs **after** AI filtering — only relevant articles are scraped
-- If a site blocks scraping or times out, the agent silently falls back to the RSS excerpt
+- If a site blocks scraping or times out, the agent prints a warning and falls back to the RSS excerpt
 - Set `enabled: false` for faster runs or if you hit many paywalled sources
 
 ---

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,10 @@ topics:
   - AI use cases for Finance Department in a bank
   - AI and Claude for software development
 
+# ── Fetch ────────────────────────────────────────────────────────────────────
+fetch:
+  lookback_hours: 24  # only include articles published within this many hours
+
 # ── Cache ────────────────────────────────────────────────────────────────────
 cache:
   expiry_days: 7  # articles seen within this many days will not be reprocessed


### PR DESCRIPTION
## Summary

Fixes all 9 bugs identified in the v1.8 code inspection (tracked in #23).

- 🔴 **Bug 1 [HIGH]**: Wrap `send_email` in per-group `try/except` — SMTP crash no longer skips remaining groups or breaks caching
- 🟠 **Bug 2 [MEDIUM]**: Guard against empty `to_email` — skips group with a printed warning instead of calling `send_email` with no recipients
- 🟠 **Bug 3 [MEDIUM]**: `config.get("feeds", [])` prevents `KeyError` when `feeds` key is absent
- 🟠 **Bug 4 [MEDIUM]**: Anchor `load_config` paths to `_BASE_DIR` (script directory) so config resolves correctly regardless of working directory
- 🟠 **Bug 5 [MEDIUM]**: Add `validate_config()` — raises `ValueError` with a clear message for missing `feeds` or missing `users`/`topics` key
- 🟡 **Bug 6 [LOW]**: `scrape_article` now logs exception type on failure instead of silently returning `None`
- 🟡 **Bug 7 [LOW]**: Remove hardcoded "finance and technology" audience from sentiment prompt
- 🟡 **Bug 8 [LOW]**: HTML-escape article titles and reject `javascript:` URIs in links (`compile_digest`)
- 🟡 **Bug 9 [LOW]**: `fetch_articles` lookback window now reads from `config.fetch.lookback_hours` (default 24); new key added to `config.yaml`

## Test plan

- [ ] Run `python3 -m unittest test_main.py -v` — all 99 tests must pass (83 existing + 16 new)
- [ ] Confirm `test_send_email_failure_does_not_skip_remaining_groups` passes
- [ ] Confirm `test_add_to_cache_called_even_when_send_email_raises` passes
- [ ] Confirm `test_empty_emails_group_is_skipped` and `test_empty_emails_prints_warning` pass
- [ ] Confirm `test_validate_config_*` tests (5 tests) pass
- [ ] Confirm `test_html_special_chars_in_title_are_escaped` and `test_javascript_uri_in_link_is_sanitized` pass
- [ ] Confirm `test_fetch_articles_uses_lookback_hours_from_config` and `test_fetch_articles_defaults_to_24_hours_when_not_in_config` pass

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)